### PR TITLE
Enable automatic device selection for TensorFlow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install numpy biopython pytest
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            python -m pip install tensorflow-macos tensorflow-metal
+          else
+            python -m pip install tensorflow
+          fi
+          python -m pip install .
+      - name: Run tests
+        run: python -m pytest

--- a/DLPacker/utils.py
+++ b/DLPacker/utils.py
@@ -50,7 +50,25 @@ import os
 import tempfile
 import traceback
 import platform
-is_arm_mac=(platform.system() == 'Darwin' and platform.machine()=='arm64')
+
+is_arm_mac = platform.system() == 'Darwin' and platform.machine() == 'arm64'
+
+
+def get_available_device():
+    """Return the best available TensorFlow device.
+
+    Prefers a GPU accelerator (CUDA or Apple's Metal backend) and falls back
+    to CPU when no accelerators are present. TensorFlow reports Apple Silicon
+    GPUs as type ``GPU``, so there's no separate ``MPS`` device listing.
+    """
+    gpus = tf.config.list_physical_devices("GPU")
+    if gpus:
+        if is_arm_mac:
+            print("Using Apple Metal GPU")
+        else:
+            print("Using CUDA GPU")
+        return "/GPU:0"
+    return "/CPU:0"
 
 
 def fetch_and_unzip_google_drive_link(gdrive_link, output_dir):
@@ -73,11 +91,10 @@ def fetch_and_unzip_google_drive_link(gdrive_link, output_dir):
         url=gdrive_link, output=output_file, quiet=False, fuzzy=True
     )
 
-
     # Extract the downloaded file
     extracted_files = []
     try:
-        
+
         import py7zr
 
         with py7zr.SevenZipFile(output_file, mode='r') as z:
@@ -198,11 +215,18 @@ class DLPModel:
         self.grid_size = grid_size  # grid size
         self.num_channels = num_channels  # number of input channels
         self.batch_size = batch_size
-        self.optimizer = tf.optimizers.Adam(lr) if not is_arm_mac else tf.keras.optimizers.legacy.Adam(lr)
+        self.optimizer = (
+            tf.optimizers.Adam(lr)
+            if not is_arm_mac
+            else tf.keras.optimizers.legacy.Adam(lr)
+        )
         self.data_gen = DataGenerator(self.batch_size, folder='./BOXES_TRAIN/')
         self.val_gen = DataGenerator(self.batch_size, folder='./BOXES_VAL/')
 
-        self.model = self.model()
+        self.device = get_available_device()
+        with tf.device(self.device):
+            self.model = self.model()
+        print(f'Using device: {self.device}')
 
         self.loss_history = {'mae': [], 'roi': []}
         self.ema = 0.999  # for loss history smoothing
@@ -236,14 +260,17 @@ class DLPModel:
         for e in range(epochs):
             start = time.time()
             for i, (x, y, labels) in enumerate(self.data_gen):
-                with tf.GradientTape() as tape:
-                    out = self.model([x, labels])
-                    l = self.loss(x[..., :4], y, labels, out)
+                with tf.device(self.device):
+                    with tf.GradientTape() as tape:
+                        out = self.model([x, labels])
+                        l = self.loss(x[..., :4], y, labels, out)
 
-                    grads = tape.gradient(l, self.model.trainable_variables)
-                    self.optimizer.apply_gradients(
-                        zip(grads, self.model.trainable_variables)
-                    )
+                        grads = tape.gradient(
+                            l, self.model.trainable_variables
+                        )
+                        self.optimizer.apply_gradients(
+                            zip(grads, self.model.trainable_variables)
+                        )
                 end = time.time()
 
                 print(
@@ -270,11 +297,12 @@ class DLPModel:
         for i, (x, y, labels) in enumerate(self.val_gen):
             if i > 0:
                 print('Batch:', i, np.mean(rois), end='\r')
-            out = self.model([x, labels])
-            x = x[..., :4]
-            mae = tf.reduce_mean(tf.math.abs(y - out))
-            mask = np.array(x != y, dtype=np.float32)
-            roi = tf.reduce_mean(tf.math.abs(y - out) * mask) * 100
+            with tf.device(self.device):
+                out = self.model([x, labels])
+                x = x[..., :4]
+                mae = tf.reduce_mean(tf.math.abs(y - out))
+                mask = np.array(x != y, dtype=np.float32)
+                roi = tf.reduce_mean(tf.math.abs(y - out) * mask) * 100
 
             maes.append(mae)
             rois.append(roi)
@@ -407,9 +435,7 @@ class InputBoxReader:
         ]
 
         # defining a kernel
-        kernel = np.exp(
-            -np.sum(self.grid * self.grid, axis=0) / SIGMA**2 / 2
-        )
+        kernel = np.exp(-np.sum(self.grid * self.grid, axis=0) / SIGMA**2 / 2)
         kernel /= np.sqrt(2 * np.pi) * SIGMA
         self.kernel = kernel[1:-1, 1:-1, 1:-1]
         self.norm = np.sum(self.kernel)

--- a/DLPacker/utils.py
+++ b/DLPacker/utils.py
@@ -63,6 +63,11 @@ def get_available_device():
     """
     gpus = tf.config.list_physical_devices("GPU")
     if gpus:
+        for gpu in gpus:
+            try:
+                tf.config.experimental.set_memory_growth(gpu, True)
+            except Exception:
+                pass
         if is_arm_mac:
             print("Using Apple Metal GPU")
         else:
@@ -256,21 +261,39 @@ class DLPModel:
             with open(history + '.pkl', 'wb') as f:
                 pickle.dump(self.loss_history, f)
 
+    @tf.function
+    def _train_step(self, x, y, labels):
+        with tf.device(self.device):
+            with tf.GradientTape() as tape:
+                out = self.model([x, labels], training=True)
+                total, mae, roi = self.loss(x[..., :4], y, labels, out)
+            grads = tape.gradient(total, self.model.trainable_variables)
+            self.optimizer.apply_gradients(zip(grads, self.model.trainable_variables))
+        return mae, roi
+
+    @tf.function
+    def _val_step(self, x, y, labels):
+        with tf.device(self.device):
+            out = self.model([x, labels], training=False)
+            _, mae, roi = self.loss(x[..., :4], y, labels, out)
+        return mae, roi
+
     def train(self, epochs: int):
         for e in range(epochs):
             start = time.time()
             for i, (x, y, labels) in enumerate(self.data_gen):
-                with tf.device(self.device):
-                    with tf.GradientTape() as tape:
-                        out = self.model([x, labels])
-                        l = self.loss(x[..., :4], y, labels, out)
+                mae, roi = self._train_step(x, y, labels)
+                mae = float(mae.numpy())
+                roi = float(roi.numpy())
+                if self.loss_history['mae']:
+                    mae_ema = mae * (1 - self.ema) + self.ema * self.loss_history['mae'][-1]
+                    self.loss_history['mae'].append(mae_ema)
+                    roi_ema = roi * (1 - self.ema) + self.ema * self.loss_history['roi'][-1]
+                    self.loss_history['roi'].append(roi_ema)
+                else:
+                    self.loss_history['mae'].append(mae)
+                    self.loss_history['roi'].append(roi)
 
-                        grads = tape.gradient(
-                            l, self.model.trainable_variables
-                        )
-                        self.optimizer.apply_gradients(
-                            zip(grads, self.model.trainable_variables)
-                        )
                 end = time.time()
 
                 print(
@@ -291,46 +314,26 @@ class DLPModel:
                     self.model.save('backup')
 
     def validate(self):
-        count = 0
         maes = []
         rois = []
         for i, (x, y, labels) in enumerate(self.val_gen):
             if i > 0:
                 print('Batch:', i, np.mean(rois), end='\r')
-            with tf.device(self.device):
-                out = self.model([x, labels])
-                x = x[..., :4]
-                mae = tf.reduce_mean(tf.math.abs(y - out))
-                mask = np.array(x != y, dtype=np.float32)
-                roi = tf.reduce_mean(tf.math.abs(y - out) * mask) * 100
-
-            maes.append(mae)
-            rois.append(roi)
+            mae, roi = self._val_step(x, y, labels)
+            maes.append(float(mae.numpy()))
+            rois.append(float(roi.numpy()))
 
         print('MAE:', np.mean(maes), 'ROI:', np.mean(rois))
 
-    def loss(self, x, y, labels, out):
+    def _compute_losses(self, x, y, out):
         mae = tf.reduce_mean(tf.math.abs(y - out))
-
-        mask = np.array(x != y, dtype=np.float32)
+        mask = tf.cast(tf.not_equal(x, y), tf.float32)
         roi = tf.reduce_mean(tf.math.abs(y - out) * mask) * 100
+        return mae, roi
 
-        if self.loss_history['mae']:
-            mae_ema = (
-                mae.numpy() * (1 - self.ema)
-                + self.ema * self.loss_history['mae'][-1]
-            )
-            self.loss_history['mae'].append(mae_ema)
-            roi_ema = (
-                roi.numpy() * (1 - self.ema)
-                + self.ema * self.loss_history['roi'][-1]
-            )
-            self.loss_history['roi'].append(roi_ema)
-        else:
-            self.loss_history['mae'].append(mae.numpy())
-            self.loss_history['roi'].append(roi.numpy())
-
-        return roi + mae
+    def loss(self, x, y, labels, out):
+        mae, roi = self._compute_losses(x, y, out)
+        return roi + mae, mae, roi
 
     def model(self):
         width = self.width

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ You can find more examples with explanations in the jupyter notebook **[DLPacker
 
 The package will automatically make use of CUDA GPUs or Apple's Metal
 Performance Shaders (MPS) when available and fall back to the CPU by
-default.
+default. Training and validation steps run under `tf.function` with GPU
+memory growth enabled for better accelerator utilization.
 
 <h2 align="center" style="color:blue">Additional files</h2>
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,12 @@ Input stricture might or might not contain side chains, existing side chains, if
 You can find more examples with explanations in the jupyter notebook **[DLPacker.ipynb](DLPacker.ipynb)**.
 
 **Key dependencies:**
-* tensorflow 2.x
+* tensorflow 2.x (use `tensorflow-macos` together with `tensorflow-metal` on Apple Silicon)
 * biopython
+
+The package will automatically make use of CUDA GPUs or Apple's Metal
+Performance Shaders (MPS) when available and fall back to the CPU by
+default.
 
 <h2 align="center" style="color:blue">Additional files</h2>
 

--- a/tests/test_device_and_pdb.py
+++ b/tests/test_device_and_pdb.py
@@ -1,0 +1,24 @@
+import urllib.request
+from pathlib import Path
+
+from DLPacker.utils import get_available_device
+from DLPacker.dlpacker import DLPacker
+from Bio.PDB import Selection
+
+
+def test_get_available_device_returns_valid():
+    device = get_available_device()
+    assert device in {"/GPU:0", "/CPU:0"}
+
+
+def test_dlpacker_reads_1ubq(tmp_path: Path):
+    pdb_file = tmp_path / "1UBQ.pdb"
+    urllib.request.urlretrieve("https://files.rcsb.org/download/1UBQ.pdb", pdb_file)
+
+    class DummyModel:
+        pass
+
+    packer = DLPacker(str_pdb=str(pdb_file), model=DummyModel())
+    residues = list(Selection.unfold_entities(packer.structure, "R"))
+    assert len(residues) == 76
+


### PR DESCRIPTION
## Summary
- detect available CUDA or MPS accelerators and fall back to CPU
- run DLPModel operations on the chosen device
- document automatic device selection
- add a test validating device detection and PDB parsing via a fetched 1UBQ file
- run tests in CI via GitHub Actions
- install `tensorflow-macos` and `tensorflow-metal` on macOS runners and adjust GPU detection to account for MPS being reported as a GPU

## Testing
- `pip install numpy biopython tensorflow pytest --quiet` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6892b497ab00832399fe81e1f172dbc5